### PR TITLE
Fix grammar in TodoList action description

### DIFF
--- a/src/app/components/TodoList.tsx
+++ b/src/app/components/TodoList.tsx
@@ -23,7 +23,7 @@ export const TodoList: React.FC = () => {
     name: "updateTodoList",
 
     // Description of what the action does
-    description: "Update the users todo list",
+    description: "Update the user's todo list",
 
     // Define the parameters that the action accepts
     parameters: [


### PR DESCRIPTION
## Summary
- fix grammar in `updateTodoList` action description

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486e5450848321b6c43c4469d48c90